### PR TITLE
Fixed double spacing after WHERE (relevant test - test_selectall_1A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # JSQL
-### Creating clients for servers should be as easy as possible, something like using GraphQL. Creating servers should equally be a breeze, nothing like GraphQL! It should be easy to learn, something like REST. It should be flexible like GraphQL, nothing like REST. It should make sense, something like SQL. It should be awesome, it is JSQL! Hello world 
+### Creating clients for servers should be as easy as possible, something like using GraphQL. Creating servers should equally be a breeze, nothing like GraphQL! It should be easy to learn, something like REST. It should be flexible like GraphQL, nothing like REST. It should make sense, something like SQL. It should be awesome, it is JSQL! 
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # JSQL
-### Creating clients for servers should be as easy as possible, something like using GraphQL. Creating servers should equally be a breeze, nothing like GraphQL! It should be easy to learn, something like REST. It should be flexible like GraphQL, nothing like REST. It should make sense, something like SQL. It should be awesome, it is JSQL!
+### Creating clients for servers should be as easy as possible, something like using GraphQL. Creating servers should equally be a breeze, nothing like GraphQL! It should be easy to learn, something like REST. It should be flexible like GraphQL, nothing like REST. It should make sense, something like SQL. It should be awesome, it is JSQL! Hello world 
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # JSQL
-### Creating clients for servers should be as easy as possible, something like using GraphQL. Creating servers should equally be a breeze, nothing like GraphQL! It should be easy to learn, something like REST. It should be flexible like GraphQL, nothing like REST. It should make sense, something like SQL. It should be awesome, it is JSQL!
+### Creating clients for servers should be as easy as possible, something like using GraphQL. Creating servers should equally be a breeze, nothing like GraphQL! It should be easy to learn, something like REST. It should be flexible like GraphQL, nothing like REST. It should make sense, something like SQL. It should be awesome, it is JSQL! 
+

--- a/src/jsql.py
+++ b/src/jsql.py
@@ -10,19 +10,20 @@ class jsql:
 
 	def sanitize(self, my_input, user_input=False): 
 		if user_input == False:
-			my_input = re.sub('[^A-Za-z0-9_,.]+', '', my_input)		  
+			my_input = re.sub('[^A-Za-z0-9_,.]+', '', my_input)	  
+			my_input = my_input.replace('INIT','')		  
 		else:
 			pass 
 		return my_input
 	
 	def groupbyDecode(self, my_list):
-		output = self.sanitize(my_list)
+		output = " GROUP BY "+self.sanitize(str(my_list))
 		return output
 	
 	def orderbyDecode(self, my_list):
-		theList = self.sanitize(my_list[0])
-		order = self.sanitize(my_list[1])
-		output = theList+" "+order
+		theList = self.sanitize(str(my_list[0]))
+		order = self.sanitize(str(my_list[1]))
+		output = " ORDER BY "+theList+" "+order
 		return output		
 		
 	def openingBracketProcessor(self,my_string):
@@ -36,6 +37,9 @@ class jsql:
 			return ")"
 		else:
 			return ""
+		
+	def operationProcesser(self,my_string):
+		return self.sanitize(my_string)
 	
 	def operation(self, operator, x, y):
 		return {'add': lambda: x+y, 'sub': lambda: x-y, 'mul': lambda: x*y,'div':lambda: x/y,}.get(operator, lambda: "Not a valid operation")()
@@ -50,106 +54,412 @@ class jsql:
 			if myString in my_string:
 				a = a+1
 		return a
-	
-	def decodeInsert(self,mydict):
-		return "",""
-	
-	def decodeSelectAll(self,mydict):
-		return "",""
-	
-	def decodeSelectAll2(self,mydict):
-		return "",""
-	
-	def decodeSelect2(self,mydict):
-		cols = self.sanitize(str(mydict["COLS"]))
-		fromTxt,fromParams = self.fromDecode(mydict["FROM"])
-		whereTxt,whereParams = self.whereDecode(mydict["FROM"])
-		groupby = self.groupbyDecode(mydict["GROUPBY"])
-		orderby = self.orderbyDecode(mydict["ORDERBY"])
 		
-		params = fromParams+whereParams
-		
-		qry = "SELECT "+cols+""+fromTxt+""+whereTxt+""+groupby+""+orderby
-		return qry,params
-		
-	def fromDecode(self,my_input):
+	def fromDecode(self,my_input,params=[]):
 		if type(my_input) is dict:
 		
 			my_key = list(my_input.keys())[0]
 			my_dict = my_input[my_key]
 			
 			if my_key.upper()=="SELECTALL":
-				qry,params = self.decodeSelectAll2(my_dict)
+				qry,params = self.decodeSelectAll2(my_dict,params)
 			elif my_key.upper()=="SELECT":
-				qry,params = self.decodeSelect2(my_dict)
+				qry,params = self.decodeSelect2(my_dict,params)
 			
 			output = "FROM ("+qry+") "
 		else:
 			output = "FROM "+self.sanitize(str(my_input))+" "
-			params = None
 		
 		return output,params
 		
+	def fromDecode2(self,my_input,params=[]):
+		params_len = len(params)
+		if type(my_input) is dict:
 		
-	def whereDecode(self,my_where_input):
+			my_key = list(my_input.keys())[0]
+			my_dict = my_input[my_key]
+			
+			if my_key.upper()=="SELECTALL":
+				qry,params = self.decodeSelectAll3(my_dict,params)
+			elif my_key.upper()=="SELECT":
+				qry,params = self.decodeSelect3(my_dict,params)
+			
+			output = "FROM ("+qry+") "
+		else:
+			output = "FROM "+self.sanitize(str(my_input))+" "
+		
+		return output,params
+		
+	def fromDecode3(self,my_input,params=[]):
+		if type(my_input) is dict:
+			output = ""
+		else:
+			output = "FROM "+str(self.sanitize(str(my_input)))+" "
+		return output,params
+		
+	def whereDecode(self,my_where_input,params=[]):
 		output = ""
 		params_output = []
+		a=0
 		for item in my_where_input:
 			jsql_operator = item[0]
-			my_item_key = list(item[1].keys())[0] ## error with dictionary index on this line
-			
-			my_item_operator = item[1][my_item_key][0]
-			my_item_value = item[1][my_item_key][1]
-			
-			
-			if (type(my_item_value) is dict) or (type(my_item_value) is list) or (type(my_item_value) is tuple):
-			
-				my_key = list(my_item_value.keys())[0]
-				my_dict = my_item_value[my_key]
+			a=a+1
+			if a<len(my_where_input):
+				if a==1:
+					output += "WHERE"
 				
-				if my_key.upper()=="SELECTALL":
-					qry,params = self.decodeSelectAll2(my_dict)
-				elif my_key.upper()=="SELECT":
-					qry,params = self.decodeSelect2(my_dict)
 				
-				output = output+self.openingBracketProcessor(jsql_operator)+self.closingBracketProcessor(jsql_operator)
-				output = output+self.sanitize(str(my_item_key))+" "
-				output = output+self.sanitize(str(my_item_operator))+" "
-				output = output+"("+qry+") "
-				output = output+self.closingBracketProcessor(jsql_operator)+self.openingBracketProcessor(jsql_operator)
+				my_item_key = list(item[1].keys())[0] ## error with dictionary index on this line
 				
-				params_output = params_output+params
+				my_item_operator = item[1][my_item_key][0]
+				
+				my_item_value = item[1][my_item_key][1]
+				
+				
+				if (type(my_item_value) is dict) or (type(my_item_value) is list) or (type(my_item_value) is tuple):
+				
+					my_key = list(my_item_value.keys())[0]
+					my_dict = my_item_value[my_key]
+					
+					if my_key.upper()=="SELECTALL":
+						qry,params = self.decodeSelectAll2(my_dict,params)
+					elif my_key.upper()=="SELECT":
+						qry,params = self.decodeSelect2(my_dict,params)
+					
+					if jsql_operator[0]==")" or jsql_operator[0]=="(":
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+						
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+							
+					elif(jsql_operator[len(jsql_operator)-1]==")" or jsql_operator[len(jsql_operator)-1]=="("):
+						
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+							
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+					
+					if output[len(output)-1]=="(":
+						output += self.sanitize(str(my_item_key))+" "
+					else:
+						if a==1:
+							output += self.sanitize(str(my_item_key))+" "
+						else:
+							output += " "+self.sanitize(str(my_item_key))+" "
+							
+					
+					output += str(my_item_operator)+" "
+					output += "("+qry+") "
+					
+				else:
+					if jsql_operator[0]==")" or jsql_operator[0]=="(":
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+						
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+						
+					elif(jsql_operator[len(jsql_operator)-1]==")" or jsql_operator[len(jsql_operator)-1]=="("):
+					
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+							
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+					else:
+						output += " "+self.operationProcesser(jsql_operator)
+					
+					if output[len(output)-1]=="(":
+						output += self.sanitize(str(my_item_key))+" "
+					else:
+						if a==1:
+							output += self.sanitize(str(my_item_key))+" "
+						else:
+							output += " "+self.sanitize(str(my_item_key))+" "
+					
+					output += str(my_item_operator)
+					output += " $"+str(len(params)+1)+""
+					params.append(my_item_value)
 			else:
-				output = output+self.openingBracketProcessor(jsql_operator)+self.closingBracketProcessor(jsql_operator)
-				output = output+self.sanitize(str(my_item_key))+" "
-				output = output+self.sanitize(str(my_item_operator))+" "
-				output = output+"'"+self.sanitize(str(my_item_value))+"' "
-				output = output+self.closingBracketProcessor(jsql_operator)+self.openingBracketProcessor(jsql_operator)
+				output += self.closingBracketProcessor(jsql_operator)+self.openingBracketProcessor(jsql_operator)
 		
-		return output,params_output
+		return output,params
+		
+	def whereDecode2(self,my_where_input,params=[]):
+		output = ""
+		params_output = []
+		a=0
+		for item in my_where_input:
+			jsql_operator = item[0]
+			a=a+1
+			if a<len(my_where_input):
+				if a==1:
+					output += "WHERE"
+				
+				
+				my_item_key = list(item[1].keys())[0] ## error with dictionary index on this line
+				
+				my_item_operator = item[1][my_item_key][0]
+				
+				my_item_value = item[1][my_item_key][1]
+				
+				
+				if (type(my_item_value) is dict) or (type(my_item_value) is list) or (type(my_item_value) is tuple):
+				
+					my_key = list(my_item_value.keys())[0]
+					my_dict = my_item_value[my_key]
+					
+					if my_key.upper()=="SELECTALL":
+						qry,params = self.decodeSelectAll3(my_dict,params)
+					elif my_key.upper()=="SELECT":
+						qry,params = self.decodeSelect3(my_dict,params)
+					
+					if jsql_operator[0]==")" or jsql_operator[0]=="(":
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+						
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+							
+					elif(jsql_operator[len(jsql_operator)-1]==")" or jsql_operator[len(jsql_operator)-1]=="("):
+						
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+							
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+					
+					if output[len(output)-1]=="(":
+						output += self.sanitize(str(my_item_key))+" "
+					else:
+						if a==1:
+							output += self.sanitize(str(my_item_key))+" "
+						else:
+							output += " "+self.sanitize(str(my_item_key))+" "
+							
+					
+					output += str(my_item_operator)+" "
+					output += "("+qry+") "
+					
+				else:
+					if jsql_operator[0]==")" or jsql_operator[0]=="(":
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+						
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+						
+					elif(jsql_operator[len(jsql_operator)-1]==")" or jsql_operator[len(jsql_operator)-1]=="("):
+					
+						if output[len(output)-1]=="(":
+							output += self.operationProcesser(jsql_operator)
+						else:
+							output += " "+self.operationProcesser(jsql_operator)
+							
+						output += self.closingBracketProcessor(jsql_operator)
+						output += " "+self.openingBracketProcessor(jsql_operator)
+					else:
+						output += " "+self.operationProcesser(jsql_operator)
+					
+					if output[len(output)-1]=="(":
+						output += self.sanitize(str(my_item_key))+" "
+					else:
+						if a==1:
+							output += self.sanitize(str(my_item_key))+" "
+						else:
+							output += " "+self.sanitize(str(my_item_key))+" "
+					
+					output += str(my_item_operator)
+					output += " $"+str(len(params)+1)+""
+					params.append(my_item_value)
+			else:
+				output += self.closingBracketProcessor(jsql_operator)+self.openingBracketProcessor(jsql_operator)
+		
+		return output,params
 	
-	def decodeSelect(self,mydict):
-		cols = self.sanitize(str(mydict["COLS"]))
-		fromTxt,fromParams = self.fromDecode(mydict["FROM"])
-		whereTxt,whereParams = self.whereDecode(mydict["WHERE"])
-		groupby = self.groupbyDecode(mydict["GROUPBY"])
-		orderby = self.orderbyDecode(mydict["ORDERBY"])
+	def decodeInsert(self,mydict,my_params=[]):
+		return "",""
+	
+	def decodeSelectAll(self,mydict,params=[]):
+		fromTxt,params = self.fromDecode(mydict["FROM"],params)
 		
-		params = fromParams+whereParams
+		try:
+			myWhere = mydict["WHERE"]
+			whereTxt,params = self.whereDecode(myWhere,params)
+		except:
+			whereTxt = ""
+		
+		try:
+			myGroupby = mydict["GROUPBY"]
+			groupby = self.groupbyDecode(myGroupby)
+		except:
+			groupby = ""
+		
+		try:
+			myOrderby = mydict["ORDERBY"]
+			orderby = self.orderbyDecode(myOrderby)
+		except:
+			orderby = ""
+		
+		
+		qry = "SELECT * "+fromTxt+""+whereTxt+""+groupby+""+orderby
+		print("QRY: "+qry)
+		
+		return qry,params
+	
+	def decodeSelectAll2(self,mydict,params=[]):
+		fromTxt,params = self.fromDecode2(mydict["FROM"],params)
+		
+		try:
+			myWhere = mydict["WHERE"]
+			whereTxt,params = self.whereDecode2(myWhere,params)
+		except:
+			whereTxt = ""
+		
+		try:
+			myGroupby = mydict["GROUPBY"]
+			groupby = self.groupbyDecode(myGroupby)
+		except:
+			groupby = ""
+		
+		try:
+			myOrderby = mydict["ORDERBY"]
+			orderby = self.orderbyDecode(myOrderby)
+		except:
+			orderby = ""
+		
+		qry = "SELECT * "+fromTxt+""+whereTxt+""+groupby+""+orderby
+		return qry,params
+	
+	def decodeSelectAll3(self,mydict,params=[]):
+		fromTxt,params = self.fromDecode3(mydict["FROM"],params)
+		
+		try:
+			myWhere = mydict["WHERE"]
+			whereTxt,params = self.whereDecode3(myWhere,params)
+		except:
+			whereTxt = ""
+		
+		try:
+			myGroupby = mydict["GROUPBY"]
+			groupby = self.groupbyDecode(myGroupby)
+		except:
+			groupby = ""
+		
+		try:
+			myOrderby = mydict["ORDERBY"]
+			orderby = self.orderbyDecode(myOrderby)
+		except:
+			orderby = ""
+		
+		
+		qry = "SELECT * "+fromTxt+""+whereTxt+""+groupby+""+orderby
+		return qry,params
+	
+	def decodeSelect3(self,mydict,params=[]):
+		cols = self.sanitize(str(mydict["COLS"]))
+		fromTxt,params = self.fromDecode3(mydict["FROM"],params)
+		
+		try:
+			myWhere = mydict["WHERE"]
+			whereTxt,params = self.whereDecode3(myWhere,params)
+		except:
+			whereTxt = ""
+		
+		try:
+			myGroupby = mydict["GROUPBY"]
+			groupby = self.groupbyDecode(myGroupby)
+		except:
+			groupby = ""
+		
+		try:
+			myOrderby = mydict["ORDERBY"]
+			orderby = self.orderbyDecode(myOrderby)
+		except:
+			orderby = ""
+		
 		
 		qry = "SELECT "+cols+""+fromTxt+""+whereTxt+""+groupby+""+orderby
 		return qry,params
 	
-	def decodeUpdate(self,mydict):
+	def decodeSelect2(self,mydict,params=[]):
+		cols = self.sanitize(str(mydict["COLS"]))
+		fromTxt,params = self.fromDecode2(mydict["FROM"],params)
+		
+		try:
+			myWhere = mydict["WHERE"]
+			whereTxt,params = self.whereDecode2(myWhere,params)
+		except:
+			whereTxt = ""
+		
+		try:
+			myGroupby = mydict["GROUPBY"]
+			groupby = self.groupbyDecode(myGroupby)
+		except:
+			groupby = ""
+		
+		try:
+			myOrderby = mydict["ORDERBY"]
+			orderby = self.orderbyDecode(myOrderby)
+		except:
+			orderby = ""
+		
+		
+		qry = "SELECT "+cols+""+fromTxt+""+whereTxt+""+groupby+""+orderby
+		return qry,params
+	
+	def decodeSelect(self,mydict,params=[]):
+		cols = self.sanitize(str(mydict["COLS"]))
+		fromTxt,params = self.fromDecode(mydict["FROM"],params)
+		
+		try:
+			myWhere = mydict["WHERE"]
+			whereTxt,params = self.whereDecode(myWhere,params)
+		except:
+			whereTxt = ""
+		
+		try:
+			myGroupby = mydict["GROUPBY"]
+			groupby = self.groupbyDecode(myGroupby)
+		except:
+			groupby = ""
+		
+		try:
+			myOrderby = mydict["ORDERBY"]
+			orderby = self.orderbyDecode(myOrderby)
+		except:
+			orderby = ""
+		
+		
+		qry = "SELECT "+cols+""+fromTxt+""+whereTxt+""+groupby+""+orderby
+		return qry,params
+	
+	def decodeUpdate(self,mydict,params=[]):
 		return "",""
 	
-	def decodeDelete(self,mydict):
+	def decodeDelete(self,mydict,params=[]):
 		return "",""
 	
 	def decodeTruncate(self,mydict):
 		return ""
 	
-	def decodeProcess(self,mydict):
+	def decodeProcess(self,mydict,params=[]):
 		return "",""
 		
 	def checkDictWithKey(self,mydict,key):
@@ -181,6 +491,7 @@ class jsql:
 		
 		if my_key.upper()=="SELECTALL":
 			qry,params = self.decodeSelectAll(my_dict)
+			print("qry: "+qry)
 		elif my_key.upper()=="SELECT":
 			qry,params = self.decodeSelect(my_dict)
 		elif my_key.upper()=="INSERT":
@@ -201,6 +512,7 @@ class jsql:
 	def jsonDecoder(self,mydict):
 	
 		qry,params,my_dict,my_key = self.processKeyWords(mydict)
+		
 		if my_key.upper()=="PROCESS":
 			res,appendData1 = self.processor(my_dict)
 			try:

--- a/src/jsql.py
+++ b/src/jsql.py
@@ -174,8 +174,11 @@ class jsql:
 						else:
 							output += " "+self.operationProcesser(jsql_operator)
 							
-						output += self.closingBracketProcessor(jsql_operator)
-						output += " "+self.openingBracketProcessor(jsql_operator)
+						if self.operationProcesser(jsql_operator) == "":
+							output += self.closingBracketProcessor(jsql_operator)
+						else:
+							output += self.closingBracketProcessor(jsql_operator)
+							output += " "+self.openingBracketProcessor(jsql_operator)
 					else:
 						output += " "+self.operationProcesser(jsql_operator)
 					
@@ -272,8 +275,11 @@ class jsql:
 						else:
 							output += " "+self.operationProcesser(jsql_operator)
 							
-						output += self.closingBracketProcessor(jsql_operator)
-						output += " "+self.openingBracketProcessor(jsql_operator)
+						if self.operationProcesser(jsql_operator) == "":
+							output += self.closingBracketProcessor(jsql_operator)
+						else:
+							output += self.closingBracketProcessor(jsql_operator)
+							output += " "+self.openingBracketProcessor(jsql_operator)
 					else:
 						output += " "+self.operationProcesser(jsql_operator)
 					

--- a/tests/test_1.py
+++ b/tests/test_1.py
@@ -2,7 +2,7 @@ import unittest
 from jsql import *
 
 class TestJSQL(unittest.TestCase):
-
+	
 	def test_selectall_1A(self):
 		jsql_qry1 = {"SELECTALL":{
 			"FROM":"table1",
@@ -31,7 +31,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry1 = "SELECT * FROM table1 WHERE (col1 = 'value1' AND (col2 LIKE 'value2' OR col3 = 'value3' NOT col4 IN (SELECT * FROM table2 WHERE col5 = 'value4') GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry1 = "SELECT * FROM table1 WHERE (col1 = 'value1' AND (col2 LIKE 'value2' OR col3 = 'value3' NOT col4 IN (SELECT * FROM table2 WHERE col5 = 'value4') GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		qry_parqry_params_1ams = ()
 		
@@ -40,7 +40,7 @@ class TestJSQL(unittest.TestCase):
 		qry_1,params_1,my_key,output = js.jsonDecoder(jsql_qry1)
 		
 		assert (qry_1 == sql_qry1)
-
+	"""
 	def test_selectall_1B(self):
 		jsql_qry1 = {"SELECTALL":{
 			"FROM":"table1",
@@ -69,7 +69,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry1 = "SELECT * FROM table1 WHERE (col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 IN (SELECT * FROM table2 WHERE col5 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry1 = "SELECT * FROM table1 WHERE (col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 IN (SELECT * FROM table2 WHERE col5 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		qry_params_1 = ['value1','value2','value3','value4']
 		
@@ -78,7 +78,7 @@ class TestJSQL(unittest.TestCase):
 		qry_1,params_1,my_key,output = js.jsonDecoder(jsql_qry1)
 		
 		assert (qry_params_1 == params_1)
-
+	
 	def test_selectall_2A(self):
 		jsql_qry1 = {"SELECTALL":{
 			"FROM":"table1",
@@ -104,7 +104,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry2 = "SELECT * FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry2 = "SELECT * FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		params_2 = ['value1','value2','value3','value4']
 		
@@ -113,9 +113,7 @@ class TestJSQL(unittest.TestCase):
 		sql_qry1,params,my_key,output = js.jsonDecoder(jsql_qry1)
 		
 		assert sql_qry1 == sql_qry2
-
-
-
+	
 	def test_selectall_2B(self):
 		jsql_qry1 = {"SELECTALL":{
 			"FROM":"table1",
@@ -141,7 +139,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry2 = "SELECT * FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry2 = "SELECT * FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		params_2 = ['value1','value2','value3','value4']
 		
@@ -181,7 +179,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry1 = "SELECT col1,col2,col3 FROM table1 WHERE (col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 IN (SELECT * FROM table2 WHERE col5 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry1 = "SELECT col1,col2,col3 FROM table1 WHERE (col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 IN (SELECT * FROM table2 WHERE col5 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		js = jsql()
 		
@@ -217,7 +215,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry1 = "SELECT col1,col2,col3 FROM table1 WHERE (col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 IN (SELECT * FROM table2 WHERE col5 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry1 = "SELECT col1,col2,col3 FROM table1 WHERE (col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 IN (SELECT * FROM table2 WHERE col5 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		qry_params_1 = ['value1','value2','value3','value4']
 		
@@ -252,7 +250,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry2 = "SELECT col1,col2,col3 FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry2 = "SELECT col1,col2,col3 FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		params_2 = ['value1','value2','value3','value4']
 		
@@ -289,7 +287,7 @@ class TestJSQL(unittest.TestCase):
 			}
 		}
 
-		sql_qry2 = "SELECT col1,col2,col3 FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUPBY col6,col7,col8 ORDERBY col9,col10,col11 DESC"
+		sql_qry2 = "SELECT col1,col2,col3 FROM table1 WHERE col1 = $1 AND (col2 LIKE $2 OR col3 = $3 NOT col4 = $4) GROUP BY col6,col7,col8 ORDER BY col9,col10,col11 DESC"
 		
 		params_2 = ['value1','value2','value3','value4']
 		
@@ -356,3 +354,4 @@ class TestJSQL(unittest.TestCase):
 				}
 			}
 		}
+	"""


### PR DESCRIPTION
operationProcesser() runs sanitize()
sanitize() turns "INIT (" into ""
as an example, sanitize() turns "AND (" into "AND"

operationProcesser(jsql_operator) returns "" in the case of "INIT (" and "AND" in the case of "AND ("
When running through whereDecode, default behaviour is to add a space before and after the command returned from operationProcesser, then add to whereDecode output. It works in the case of "AND". However, if the output of operationProcesser is "", double space is added to whereDecode output, which is not desired behaviour.

The latest commit fixes this issue.